### PR TITLE
Add CPU opponent and enhance player visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -90,26 +90,34 @@ body {
 }
 
 .cell.player {
-  background: #FFD700;
-  color: #FF6B6B;
-  animation: playerPulse 1s infinite alternate;
+    background: #FFD700;
+    color: #FF6B6B;
+    animation: playerPulse 1s infinite alternate;
+    border: 2px solid #000;
 }
 
 .player-img {
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    filter: drop-shadow(0 0 4px #000);
 }
 
 .cell.exit {
-  background: #FF69B4;
-  color: white;
+    background: #FF69B4;
+    color: white;
   animation: exitGlow 1s infinite alternate;
 }
 
 .cell.unknown {
-  background: #444;
-  color: #666;
+    background: #444;
+    color: #666;
+}
+
+.cell.cpu {
+    background: #87CEEB;
+    color: #000;
+    animation: playerPulse 1s infinite alternate;
 }
 
 /* アニメーション */


### PR DESCRIPTION
## Summary
- add CPU opponent that spawns far from the player and races to the exit
- show which side wins by touching the door first
- highlight player sprite with border and shadow for better visibility

## Testing
- `node -c script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c879d416083309627389695b1dc92