### PR TITLE
Add background music

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,8 @@
         </footer>
     </div>
 
+    <audio id="bgm" src="audio/Tokyo_Dungeon.mp3" loop></audio>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -46,6 +46,7 @@ const downBtn = document.getElementById('downBtn');
 const leftBtn = document.getElementById('leftBtn');
 const rightBtn = document.getElementById('rightBtn');
 const restartBtn = document.getElementById('restartBtn');
+const bgm = document.getElementById('bgm');
 
 // オーディオ設定
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -341,6 +342,7 @@ function movePlayer(dx, dy) {
     playStepSound();
     if (!ambienceStarted) {
         playForestAmbience();
+        bgm.play();
         ambienceStarted = true;
     }
     


### PR DESCRIPTION
## Summary
- add Tokyo Dungeon track as looping background music
- play BGM on first player move alongside ambience

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890185d6d608330a1a7ffa3b96eb049