### PR TITLE
fix: ensure player can move at start

### DIFF
--- a/script.js
+++ b/script.js
@@ -155,6 +155,10 @@ function generateField() {
     gameState.player.x = 1;
     gameState.player.y = 1;
     gameState.field[1][1] = CELL_TYPES.PATH;
+
+    // プレイヤーが開始直後に動けるように右と下のマスを必ず道にする
+    gameState.field[1][2] = CELL_TYPES.PATH;
+    gameState.field[2][1] = CELL_TYPES.PATH;
     
     // 出口の位置を設定（右下の角近く）
     gameState.exit.x = size - 2;


### PR DESCRIPTION
## Summary
- ensure player spawn has open path so game always starts with valid movement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689067d80f308330a9949f1e6f6f7e74