### PR TITLE
Add scoreboard for player and CPU wins

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
     <div class="game-container">
         <header class="game-header">
             <h1>🌲 迷い森からの脱出</h1>
+            <div class="scoreboard">
+                <div>あなた <span id="playerWins">0</span>勝</div>
+                <div>CPU <span id="cpuWins">0</span>勝</div>
+            </div>
             <div class="game-info">
                 <div class="steps">歩数: <span id="stepCount">0</span></div>
                 <div class="status">状態: <span id="gameStatus">探索中</span></div>

--- a/script.js
+++ b/script.js
@@ -48,6 +48,16 @@ const rightBtn = document.getElementById('rightBtn');
 const restartBtn = document.getElementById('restartBtn');
 const bgm = document.getElementById('bgm');
 
+const playerWinsEl = document.getElementById('playerWins');
+const cpuWinsEl = document.getElementById('cpuWins');
+let playerWins = 0;
+let cpuWins = 0;
+
+function updateScoreboard() {
+    playerWinsEl.textContent = playerWins;
+    cpuWinsEl.textContent = cpuWins;
+}
+
 // オーディオ設定
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 let ambienceStarted = false;
@@ -91,6 +101,11 @@ function playForestAmbience() {
 function finishGame(winner) {
     gameState.gameOver = true;
     gameState.winner = winner;
+    if (winner === 'player') {
+        playerWins++;
+    } else if (winner === 'cpu') {
+        cpuWins++;
+    }
     clearInterval(cpuInterval);
 }
 
@@ -232,6 +247,7 @@ function updateDisplay() {
 // UI の更新
 function updateUI() {
     stepCount.textContent = gameState.steps;
+    updateScoreboard();
 
     if (gameState.gameOver) {
         if (gameState.winner === 'player') {

--- a/style.css
+++ b/style.css
@@ -40,11 +40,16 @@ body {
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
 }
 
-.game-info {
+
+.game-info, .scoreboard {
   display: flex;
   justify-content: space-around;
   font-size: 1.1em;
   font-weight: bold;
+}
+
+.scoreboard {
+  margin-bottom: 10px;
 }
 
 /* ゲームフィールド */


### PR DESCRIPTION
## Summary
- Show running win counts for player and CPU at the top of the game
- Style the scoreboard to match existing header elements
- Track and update win totals when games finish

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68912408326c8330ba744ad9534949b0