### PR TITLE
Disable double-tap zoom during gameplay

### DIFF
--- a/script.js
+++ b/script.js
@@ -61,6 +61,16 @@ const cpuWinsEl = document.getElementById('cpuWins');
 let playerWins = 0;
 let cpuWins = 0;
 
+// ダブルタップによる拡大を防止
+let lastTouchEnd = 0;
+document.addEventListener('touchend', (e) => {
+    const now = Date.now();
+    if (now - lastTouchEnd <= 300) {
+        e.preventDefault();
+    }
+    lastTouchEnd = now;
+}, { passive: false });
+
 function updateScoreboard() {
     playerWinsEl.textContent = playerWins;
     cpuWinsEl.textContent = cpuWins;


### PR DESCRIPTION
## Summary
- prevent double-tap zoom by intercepting touchend events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973833e23c8330a7ad08bb157bd359